### PR TITLE
Fix internal fragmentation calculation in table snapshot

### DIFF
--- a/src/memsim/memory.py
+++ b/src/memsim/memory.py
@@ -92,8 +92,8 @@ class MemoryManager:
             frag_interna = 0
             
             if pid is not None and pid in process_sizes:
-                # Calculate internal fragmentation: partition_size - process_size
-                frag_interna = partition.size - process_sizes[pid]
+                # Calculate internal fragmentation ensuring it is never negative
+                frag_interna = partition.frag_interna(process_sizes[pid])
             elif pid is not None:
                 # If process size not found, assume no fragmentation
                 frag_interna = 0


### PR DESCRIPTION
## Summary
- ensure MemoryManager.table_snapshot uses Partition.frag_interna to avoid negative fragmentation values when a process exceeds its partition

## Testing
- PYTHONPATH=. poetry run pytest tests/test_memory.py::TestMemoryManager::test_table_snapshot_basic


------
https://chatgpt.com/codex/tasks/task_e_68d32c49f158832ebad1dec6a7ec71f4